### PR TITLE
Bug: Sub-characters following whitespace rendering

### DIFF
--- a/src/main/kotlin/figure/FigureBuilder.kt
+++ b/src/main/kotlin/figure/FigureBuilder.kt
@@ -9,7 +9,7 @@ internal class FigureBuilder(
     private val font: FigFont
 ) {
     private val rows = Array(font.height) { FigureRowBuilder() }
-    private var startedLine = false
+    private var lineStarted = false
 
     fun append(text: String) {
         val horizontalLayout = font.horizontalLayout
@@ -17,28 +17,17 @@ internal class FigureBuilder(
             font[codePoint]?.rows
         }
 
-        // TODO: Handling newlines
+        rowsToAppend.forEach { figCharRows ->
+            // TODO: Handling newlines
 
-        when (horizontalLayout) {
-            HorizontalLayoutMode.FullWidth -> rowsToAppend.forEach { rows ->
-                appendFullWidth(rows)
+            when {
+                lineStarted -> appendFullWidth(figCharRows)
+                horizontalLayout == HorizontalLayoutMode.FullWidth -> appendFullWidth(figCharRows)
+                horizontalLayout == HorizontalLayoutMode.Kerning -> appendKerning(figCharRows)
+                horizontalLayout == HorizontalLayoutMode.Smushing -> appendSmushing(figCharRows)
             }
-            HorizontalLayoutMode.Kerning -> rowsToAppend.forEach { rows ->
-                if (startedLine) {
-                    appendKerning(rows)
-                } else {
-                    appendFullWidth(rows)
-                    startedLine = true
-                }
-            }
-            HorizontalLayoutMode.Smushing -> rowsToAppend.forEach { rows ->
-                if (startedLine) {
-                    appendSmushing(rows)
-                } else {
-                    appendFullWidth(rows)
-                    startedLine = true
-                }
-            }
+
+            lineStarted = true
         }
     }
 

--- a/src/main/kotlin/font/FigChar.kt
+++ b/src/main/kotlin/font/FigChar.kt
@@ -5,12 +5,12 @@ package font
  * representing a single character in a [FigFont].
  */
 public data class FigChar internal constructor(
-    internal val lines: List<FigCharLine>
+    internal val rows: List<FigCharRow>
 ) {
     val width: Int
-        get() = lines[0].length
+        get() = rows[0].length
 
     val height: Int
-        get() = lines.size
+        get() = rows.size
 }
 

--- a/src/main/kotlin/font/FigCharRow.kt
+++ b/src/main/kotlin/font/FigCharRow.kt
@@ -3,7 +3,7 @@ package font
 import util.leading
 import util.trailing
 
-internal class FigCharLine {
+internal class FigCharRow {
     val leadingSpaces: Int
     val trailingSpaces: Int
     val trimmedCodePoints: List<Int>
@@ -18,7 +18,7 @@ internal class FigCharLine {
         }
     }
 
-    private constructor(other: FigCharLine, smushResult: Int) {
+    private constructor(other: FigCharRow, smushResult: Int) {
         leadingSpaces = other.leadingSpaces
         trailingSpaces = other.trailingSpaces
         trimmedCodePoints = other.trimmedCodePoints
@@ -35,7 +35,7 @@ internal class FigCharLine {
             else -> leadingSpaces + trailingSpaces + trimmedCodePoints.size
         }
 
-    infix fun butStartsWith(smushResult: Int): FigCharLine {
-        return FigCharLine(this, smushResult)
+    infix fun butStartsWith(smushResult: Int): FigCharRow {
+        return FigCharRow(this, smushResult)
     }
 }

--- a/src/main/kotlin/font/parse/ParseFigChars.kt
+++ b/src/main/kotlin/font/parse/ParseFigChars.kt
@@ -1,7 +1,7 @@
 package font.parse
 
 import font.FigChar
-import font.FigCharLine
+import font.FigCharRow
 import java.io.BufferedReader
 import kotlin.streams.toList
 
@@ -45,32 +45,32 @@ private fun parseCodeTag(src: BufferedReader): Int? {
 }
 
 private fun parseSingleLetter(src: BufferedReader, maxLength: Int, height: Int): FigChar {
-    val firstLine = readLetterLine(src, maxLength)
-    val lines = mutableListOf(firstLine)
+    val firstRow = readSubCharRow(src, maxLength)
+    val rows = mutableListOf(firstRow)
 
     repeat(height - 1) {
-        val line = readLetterLine(src, maxLength)
-        if (line.length != firstLine.length) {
-            throw Exception("Expected a width of ${firstLine.length}, found ${line.length} characters")
+        val row = readSubCharRow(src, maxLength)
+        if (row.length != firstRow.length) {
+            throw Exception("Expected a width of ${firstRow.length}, found ${row.length} characters")
         }
 
-        lines.add(line)
+        rows.add(row)
     }
 
-    return FigChar(lines)
+    return FigChar(rows)
 }
 
-private fun readLetterLine(src: BufferedReader, maxLength: Int): FigCharLine {
-    val line = src.readLine()
+private fun readSubCharRow(src: BufferedReader, maxLength: Int): FigCharRow {
+    val subCharRow = src.readLine()
         ?: throw Exception("Unexpected end of sub-character input")
 
-    if (line.length > maxLength) {
-        throw Exception("Character line width exceeds specified max length (${line.length} > $maxLength)")
+    if (subCharRow.length > maxLength) {
+        throw Exception("Sub-character row width exceeds specified max length (${subCharRow.length} > $maxLength)")
     }
 
-    val subChars = line.split('@')[0]
+    val subChars = subCharRow.split('@')[0]
         .codePoints()
         .toList()
 
-    return FigCharLine(subChars)
+    return FigCharRow(subChars)
 }


### PR DESCRIPTION
Edit: So this wasn't affecting _only_ descenders; this bug was visible when any sub-character row was only preceded by whitespace.

Before: 
```
  _____ _       _
 |  ___(_) __ _| |__  _   _
 | |_  | |/ _` | '_ \| | | |
 |  _| | | (_| | |_) | |_| |
 |_|   |_|\__, |_.__/ \__, |
  |___/       |___/
```

After:
```
  _____ _       _
 |  ___(_) __ _| |__  _   _
 | |_  | |/ _` | '_ \| | | |
 |  _| | | (_| | |_) | |_| |
 |_|   |_|\__, |_.__/ \__, |
          |___/       |___/
```